### PR TITLE
Add email & domains info - check_git_config_email

### DIFF
--- a/pre_commit_hooks/check_git_config_email.py
+++ b/pre_commit_hooks/check_git_config_email.py
@@ -33,6 +33,8 @@ def main(argv=None):
         user_email = user_email.decode().strip()
         if not any((user_email.endswith(x) for x in args.domains)):
             print("Git config email is from an unexpected domain.")
+            print("Git config email: " + user_email)
+            print("Expected domains: " + str(args.domains))
             retval = 1
 
     return retval


### PR DESCRIPTION
Indicating git config email and expected domains info after "Git config email is from an unexpected domain.".

![image](https://user-images.githubusercontent.com/23168063/138454567-52c2fe07-603b-4672-b5c3-d0b355fa4c11.png)
