### PR TITLE
making munki repo more flexible

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -66,7 +66,7 @@
   description: This hook checks Munki pkginfo files to ensure they are valid.
   entry: check-munki-pkgsinfo
   language: python
-  files: "^pkgsinfo/"
+  files: "pkgsinfo/"
   types: [text]
 
 - id: check-munkiadmin-scripts

--- a/pre_commit_hooks/munki_makecatalogs.py
+++ b/pre_commit_hooks/munki_makecatalogs.py
@@ -14,6 +14,8 @@ def build_argument_parser():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    parser.add_argument("--munki_repo", default='.',
+                        help="path to local munki repo defaults to '.'")
     # TODO: Support makecatalogs options, ideally with kwargs for flexibility.
     return parser
 
@@ -21,8 +23,8 @@ def build_argument_parser():
 def main(argv=None):
     """Main process."""
 
-    # Path to Python 2.
-    python = "/usr/bin/python"
+    # Path to munki's python.
+    python = "/usr/local/munki/munki-python"
 
     # Path to makecatalogs.
     makecatalogs = "/usr/local/munki/makecatalogs"
@@ -32,7 +34,7 @@ def main(argv=None):
     args = argparser.parse_args(argv)
 
     retval = 0
-    if not os.path.isdir("pkgsinfo"):
+    if not os.path.isdir(os.path.join(args.munki_repo, "pkgsinfo")):
         print("Could not find pkgsinfo folder.")
         retval = 1
     elif not os.path.isfile(python):
@@ -42,7 +44,7 @@ def main(argv=None):
         print("{} does not exist.".format(makecatalogs))
         retval = 1
     else:
-        retval = subprocess.call([python, makecatalogs, "."])
+        retval = subprocess.call([makecatalogs, args.munki_repo])
 
     return retval
 


### PR DESCRIPTION
I was looking to use these pre-commit's on my munki repo, but it didn't quite work for me because my "pkgsinfo" folder was not at root, these changes allowed me to get it working. 
```
      - id: munki-makecatalogs
        args: ['--munki_repo', './repo']
```
I also update the 'makecatalogs' to run without the mac installed python as python2 is no longer installed by default. 