### PR TITLE
Update munki_makecatalogs.py

### DIFF
--- a/pre_commit_hooks/munki_makecatalogs.py
+++ b/pre_commit_hooks/munki_makecatalogs.py
@@ -35,9 +35,6 @@ def main(argv=None):
     if not os.path.isdir(os.path.join(args.munki_repo, "pkgsinfo")):
         print("Could not find pkgsinfo folder.")
         retval = 1
-    elif not os.path.isfile(python):
-        print("{} does not exist.".format(python))
-        retval = 1
     elif not os.path.isfile(makecatalogs):
         print("{} does not exist.".format(makecatalogs))
         retval = 1


### PR DESCRIPTION
It looks like you updated this to stop looking defining python, but missed the main where it checks for the existence of the python variable.

error i see on `v1.14.1`

```
Run Munki Makecatalogs...................................................Failed
- hook id: munki-makecatalogs
- exit code: 1

Traceback (most recent call last):
  File "/Users/kbrewer/.cache/pre-commit/repoehdjx6fz/py_env-python3.12/bin/munki-makecatalogs", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/kbrewer/.cache/pre-commit/repoehdjx6fz/py_env-python3.12/lib/python3.12/site-packages/pre_commit_hooks/munki_makecatalogs.py", line 38, in main
    elif not os.path.isfile(python):
                            ^^^^^^
NameError: name 'python' is not defined
```