### PR TITLE
Add the ability to provide munki_repo location and only warn about missing icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,22 @@ After adding a hook to your pre-commit config, it's not a bad idea to run `pre-c
 
     This hook checks Munki pkginfo files to ensure they are valid.
 
-    - Specify your preferred list of pkginfo catalogs, if you wish to enforce it, followed by `--` to signal the end of the list:  
+    - Specify your preferred list of pkginfo catalogs, if you wish to enforce it, followed by `--` to signal the end of the list:
         `args: ['--catalogs', 'testing', 'stable', '--']`
 
-    - Specify your preferred list of pkginfo categories, if you wish to enforce it, followed by `--`:  
+    - Specify your preferred list of pkginfo categories, if you wish to enforce it, followed by `--`:
         `args: ['--categories', 'Productivity', 'Design', 'Utilities', 'Web Browsers', '--']`
 
-    - Specify required pkginfo keys, followed by `--`:  
-        `args: ['--required-keys', 'category', 'description', 'developer', 'name', 'version', '--']`  
+    - Specify required pkginfo keys, followed by `--`:
+        `args: ['--required-keys', 'category', 'description', 'developer', 'name', 'version', '--']`
         (default: description, name)
+
+    - Specify an alternate munki repo location by passing the argument:
+        `args: ['--munki-repo', './my_repo_location']`
+        (default: ".")
+
+    - Choose to just warn on missing icons with a flag, note if no other issues exist this will allow pre-commit to pass without seeing the warnings:
+        `args: ['--warn-on-missing-icons]`
 
 - __check-munkiadmin-scripts__
 

--- a/pre_commit_hooks/check_munki_pkgsinfo.py
+++ b/pre_commit_hooks/check_munki_pkgsinfo.py
@@ -36,12 +36,12 @@ def build_argument_parser():
     )
     parser.add_argument("filenames", nargs="*", help="Filenames to check.")
     parser.add_argument(
-        "--munki_repo",
+        "--munki-repo",
         default=".",
         help="path to local munki repo defaults to '.'"
     )
     parser.add_argument(
-        "--warn_on_missing_icons",
+        "--warn-on-missing-icons",
         help="If added, this will only warn on missing icons.",
         action="store_true",
         default=False,

--- a/pre_commit_hooks/check_munki_pkgsinfo.py
+++ b/pre_commit_hooks/check_munki_pkgsinfo.py
@@ -146,7 +146,7 @@ def main(argv=None):
 
         # Check for missing or case-conflicted installer items
         if not _check_case_sensitive_path(
-            os.path.join("pkgs", pkginfo.get("installer_item_location", ""))
+            os.path.join(args.munki_repo, "pkgs", pkginfo.get("installer_item_location", ""))
         ):
             print(
                 "{}: installer item does not exist or path is not case sensitive".format(

--- a/pre_commit_hooks/check_munki_pkgsinfo.py
+++ b/pre_commit_hooks/check_munki_pkgsinfo.py
@@ -35,6 +35,8 @@ def build_argument_parser():
         help="Require a blocking_applications array for pkg installers.",
     )
     parser.add_argument("filenames", nargs="*", help="Filenames to check.")
+    parser.add_argument("--munki_repo", default='.',
+                        help="path to local munki repo defaults to '.'")
     return parser
 
 
@@ -174,7 +176,8 @@ def main(argv=None):
         if not any(
             (
                 pkginfo.get("icon_name"),
-                os.path.isfile("icons/{}.png".format(pkginfo["name"])),
+                os.path.isfile(os.path.join(args.munki_repo,
+                               "icons/{}.png".format(pkginfo["name"]))),
                 pkginfo.get("installer_type") == "apple_update_metadata",
             )
         ):

--- a/pre_commit_hooks/check_munki_pkgsinfo.py
+++ b/pre_commit_hooks/check_munki_pkgsinfo.py
@@ -35,8 +35,17 @@ def build_argument_parser():
         help="Require a blocking_applications array for pkg installers.",
     )
     parser.add_argument("filenames", nargs="*", help="Filenames to check.")
-    parser.add_argument("--munki_repo", default='.',
-                        help="path to local munki repo defaults to '.'")
+    parser.add_argument(
+        "--munki_repo",
+        default=".",
+        help="path to local munki repo defaults to '.'"
+    )
+    parser.add_argument(
+        "--warn_on_missing_icons",
+        help="If added, this will only warn on missing icons.",
+        action="store_true",
+        default=False,
+    )
     return parser
 
 
@@ -176,13 +185,19 @@ def main(argv=None):
         if not any(
             (
                 pkginfo.get("icon_name"),
-                os.path.isfile(os.path.join(args.munki_repo,
-                               "icons/{}.png".format(pkginfo["name"]))),
+                os.path.isfile(
+                    os.path.join(
+                        args.munki_repo, "icons/{}.png".format(pkginfo["name"])
+                    )
+                ),
                 pkginfo.get("installer_type") == "apple_update_metadata",
             )
         ):
-            print("{}: missing icon".format(filename))
-            retval = 1
+            if args.warn_on_missing_icons:
+                print("WARNING: {}: missing icon".format(filename))
+            else:
+                print("{}: missing icon".format(filename))
+                retval = 1
 
         # Ensure uninstall method is set correctly if uninstall_script exists.
         if "uninstall_script" in pkginfo:


### PR DESCRIPTION
Adds the ability to pass in the munki repo location, keeping previous default. 
Adds the ability to warn on missing icons instead of fail. 

allows me to configure it as such: 

```
repos:
  - repo: https://github.com/homebysix/pre-commit-macadmin
    rev: v1.14.1
    hooks:
      - id: check-munki-pkgsinfo
        args: ["--munki_repo", "./repo", "--warn_on_missing_icons"]

```