### PR TITLE
Adding consistency to args for makecalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ After adding a hook to your pre-commit config, it's not a bad idea to run `pre-c
 
     This hook runs the "makecatalogs" command to ensure all referenced packages are present and catalogs are up to date.
 
+    - Specify an alternate munki repo location by passing the argument:
+        `args: ['--munki-repo', './my_repo_location']`
+        (default: ".")
+
 ## Note about combining arguments
 
 When combining arguments that take lists (for example: `--required-keys`, `--catalogs`, and `--categories`), only the _last_ list needs to have a trailing `--`. For example, if you use the check-munki-pkgsinfo hook with only the `--catalogs` argument, your yaml config would look like this:

--- a/pre_commit_hooks/munki_makecatalogs.py
+++ b/pre_commit_hooks/munki_makecatalogs.py
@@ -15,7 +15,7 @@ def build_argument_parser():
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "--munki_repo", default=".", help="Path to local Munki repo. (Defaults to '.')"
+        "--munki-repo", default=".", help="Path to local Munki repo. (Defaults to '.')"
     )
     # TODO: Support makecatalogs options, ideally with kwargs for flexibility.
     return parser


### PR DESCRIPTION
After the comment on #73 I went back to update the arg I added to this pre-commit action to be consistent. 

`args: ['--munki-repo', './my_repo_location']`
