### PR TITLE
update shebangs and allow for more passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ After adding a hook to your pre-commit config, it's not a bad idea to run `pre-c
     - Choose to just warn on missing icons with a flag, note if no other issues exist this will allow pre-commit to pass without seeing the warnings:
         `args: ['--warn-on-missing-icons]`
 
+    - Add additional shebangs that are valid for your environment:
+        `args: ['--valid-shebangs', '#!/bin/macadmin/python37', '#!/bin/macadmin/python42', '--']`
+
 - __check-munkiadmin-scripts__
 
     This hook ensures MunkiAdmin scripts are executable.

--- a/pre_commit_hooks/check_munki_pkgsinfo.py
+++ b/pre_commit_hooks/check_munki_pkgsinfo.py
@@ -223,6 +223,7 @@ def main(argv=None):
             "#!/usr/bin/osascript",
             "#!/usr/bin/perl",
             "#!/usr/bin/python3",
+            "#!/usr/bin/python",
             "#!/usr/bin/ruby",
             "#!/usr/local/munki/munki-python",
             "#!/usr/local/munki/Python.framework/Versions/Current/bin/python3",

--- a/pre_commit_hooks/check_munki_pkgsinfo.py
+++ b/pre_commit_hooks/check_munki_pkgsinfo.py
@@ -46,6 +46,12 @@ def build_argument_parser():
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--valid-shebangs",
+        nargs="+",
+        default=[],
+        help="Add other valid shebangs for your environment"
+    )
     return parser
 
 
@@ -210,17 +216,18 @@ def main(argv=None):
                 retval = 1
 
         # Ensure all pkginfo scripts have a proper shebang.
-        shebangs = (
+        builtin_shebangs = [
             "#!/bin/bash",
             "#!/bin/sh",
             "#!/bin/zsh",
             "#!/usr/bin/osascript",
             "#!/usr/bin/perl",
-            "#!/usr/bin/python",
+            "#!/usr/bin/python3",
             "#!/usr/bin/ruby",
             "#!/usr/local/munki/munki-python",
             "#!/usr/local/munki/Python.framework/Versions/Current/bin/python3",
-        )
+        ]
+        shebangs = builtin_shebangs + args.valid_shebangs
         script_types = (
             "installcheck_script",
             "uninstallcheck_script",


### PR DESCRIPTION
1. update the valid shebang list to point at python3 instead of python. 
2. add a way to incorporate additional valid shebangs that are good for different environments, in our case we have special python installed that we can depend upon. 
3. updated readme