### PR TITLE
Validate all result tags are closed

### DIFF
--- a/pre_commit_hooks/check_jamf_extension_attributes.py
+++ b/pre_commit_hooks/check_jamf_extension_attributes.py
@@ -3,7 +3,7 @@
 """Check Jamf extension attributes for common issues."""
 
 import argparse
-import os
+import re
 
 
 def build_argument_parser():
@@ -29,8 +29,12 @@ def main(argv=None):
             ea_content = openfile.read()
 
         if "<result>" not in ea_content or "</result>" not in ea_content:
-            print("{}: missing <result> and/or </result> tags".format(filename))
+            print(f"{filename}: missing <result> and/or </result> tags")
             retval = 1
+        all_results = len(re.findall("result.*\/result", ea_content))
+        proper_results = len(re.findall("<.*>.*<\/.*>", ea_content))
+        if proper_results < all_results:
+            print(f"{filename}: has an incomplete <result> tags!")
 
     return retval
 

--- a/pre_commit_hooks/check_jamf_extension_attributes.py
+++ b/pre_commit_hooks/check_jamf_extension_attributes.py
@@ -34,7 +34,7 @@ def main(argv=None):
         all_results = len(re.findall("result.*\/result", ea_content))
         proper_results = len(re.findall("<result>.*<\/result>", ea_content))
         if proper_results < all_results:
-            print(f"{filename}: has an incomplete <result> tags!")
+            print(f"{filename}: has incomplete <result> tags!")
 
     return retval
 

--- a/pre_commit_hooks/check_jamf_extension_attributes.py
+++ b/pre_commit_hooks/check_jamf_extension_attributes.py
@@ -32,7 +32,7 @@ def main(argv=None):
             print(f"{filename}: missing <result> and/or </result> tags")
             retval = 1
         all_results = len(re.findall("result.*\/result", ea_content))
-        proper_results = len(re.findall("<.*>.*<\/.*>", ea_content))
+        proper_results = len(re.findall("<result>.*<\/result>", ea_content))
         if proper_results < all_results:
             print(f"{filename}: has an incomplete <result> tags!")
 


### PR DESCRIPTION
Added a check to validate that all <result> tags are closed. Found that this wasn't being flagged on our EA's and figured I'd add it here instead of writing another hook :) 

Example:

```sh
echo "<result>test</result"
```
```log
test.sh: has an incomplete <result> tags!
```