### PR TITLE
feat: add `--warn-on-missing-installer-items` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ After adding a hook to your pre-commit config, it's not a bad idea to run `pre-c
     - Choose to just warn if icons referenced in pkginfo files are missing (this will allow pre-commit checks to pass if no other issues exist):
         `args: ['--warn-on-missing-icons]`
 
+    - Choose to just warn if installer items (`installer_item_location`) referenced in pkginfo files are missing (this will allow pre-commit checks to pass if no other issues exist):
+        `args: ['--warn-on-missing-installer-items]`
+
     - Choose to just warn if pkg/pkginfo files with __1 (or similar) suffixes are detected (this will allow pre-commit checks to pass if no other issues exist):
         `args: ['--warn-on-duplicate-imports]`
 

--- a/pre_commit_hooks/check_munki_pkgsinfo.py
+++ b/pre_commit_hooks/check_munki_pkgsinfo.py
@@ -47,6 +47,12 @@ def build_argument_parser():
         default=False,
     )
     parser.add_argument(
+        "--warn-on-missing-installer-items",
+        help="If added, this will only warn on missing installer items.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "--warn-on-duplicate-imports",
         help="If added, this will only warn if pkginfo/pkg files end with a __1 suffix.",
         action="store_true",
@@ -144,10 +150,12 @@ def main(argv=None):
                 args.munki_repo, "pkgs", pkginfo.get("installer_item_location", "")
             )
         ):
-            print(
-                f"{filename}: installer item does not exist or path is not case sensitive"
-            )
-            retval = 1
+            msg =  "installer item does not exist or path is not case sensitive"
+            if args.warn_on_missing_installer_items:
+                print(f"{filename}: WARNING: {msg}")
+            else:
+                print(f"{filename}: {msg}")
+                retval = 1
 
         # Check for pkg filenames showing signs of duplicate imports.
         if pkginfo.get("installer_item_location", "").endswith(tuple(dupe_suffixes)):

--- a/pre_commit_hooks/check_munki_pkgsinfo.py
+++ b/pre_commit_hooks/check_munki_pkgsinfo.py
@@ -150,7 +150,7 @@ def main(argv=None):
                 args.munki_repo, "pkgs", pkginfo.get("installer_item_location", "")
             )
         ):
-            msg =  "installer item does not exist or path is not case sensitive"
+            msg = "installer item does not exist or path is not case sensitive"
             if args.warn_on_missing_installer_items:
                 print(f"{filename}: WARNING: {msg}")
             else:


### PR DESCRIPTION
This PR adds a `--warn-on-missing-installer-items` option to avoid failing checks when an installer item referenced by the `installer_item_location` key in a pkgsinfo file is missing.

This is useful for workflows where Munki is run in CI/CD and large installer files are not stored directly in the repository (and are instead stored in cloud storage or via Git LFS, etc).

This is implemented very similarly to the existing `--warn-on-missing-icons` option.