### PR TITLE
Preference manifest check improvements

### DIFF
--- a/pre_commit_hooks/check_jamf_json_manifests.py
+++ b/pre_commit_hooks/check_jamf_json_manifests.py
@@ -22,7 +22,7 @@ MANIFEST_TYPES = {
     "number": int,
     "object": dict,
     "real": float,
-    "string": str
+    "string": str,
 }
 
 # List keys and their expected item types

--- a/pre_commit_hooks/check_jamf_json_manifests.py
+++ b/pre_commit_hooks/check_jamf_json_manifests.py
@@ -12,18 +12,18 @@ from datetime import datetime
 from pre_commit_hooks.util import PLIST_TYPES, validate_required_keys
 
 # Types found in the Jamf JSON manifests
-MANIFEST_TYPES = (
-    "array",
-    "boolean",
-    "data",
-    "date",
-    "float",
-    "integer",
-    "number",
-    "object",
-    "real",
-    "string",
-)
+MANIFEST_TYPES = {
+    "array": list,
+    "boolean": bool,
+    "data": str,
+    "date": datetime,
+    "float": float,
+    "integer": int,
+    "number": int,
+    "object": dict,
+    "real": float,
+    "string": str
+}
 
 # List keys and their expected item types
 MANIFEST_LIST_TYPES = {
@@ -132,9 +132,9 @@ def validate_default(name, prop, type_found, filename):
                 actual_type = str
             else:
                 actual_type = type(prop[test_key])
-            if actual_type != PLIST_TYPES.get(type_found):
+            if actual_type != MANIFEST_TYPES.get(type_found):
                 print(
-                    f"{filename}: {test_key} value for {name} should be {PLIST_TYPES.get(type_found)}, not {type(prop[test_key])}"
+                    f"{filename}: {test_key} value for {name} should be {MANIFEST_TYPES.get(type_found)}, not {type(prop[test_key])}"
                 )
                 passed = False
 

--- a/pre_commit_hooks/check_jamf_json_manifests.py
+++ b/pre_commit_hooks/check_jamf_json_manifests.py
@@ -9,7 +9,7 @@ import argparse
 import json
 from datetime import datetime
 
-from pre_commit_hooks.util import PLIST_TYPES, validate_required_keys
+from pre_commit_hooks.util import validate_required_keys
 
 # Types found in the Jamf JSON manifests
 MANIFEST_TYPES = {

--- a/pre_commit_hooks/check_preference_manifests.py
+++ b/pre_commit_hooks/check_preference_manifests.py
@@ -184,7 +184,9 @@ def validate_pfm_type_strings(subkey, filename):
         print(f'{filename}: WARNING: Subkey type "{subkey["pfm_type"]}" is deprecated')
         # passed = False
     elif subkey["pfm_type"] not in PLIST_TYPES:
-        print(f'{filename}: Unexpected subkey type {subkey["pfm_type"]} for {subkey.get("pfm_name")}')
+        print(
+            f'{filename}: Unexpected subkey type {subkey["pfm_type"]} for {subkey.get("pfm_name")}'
+        )
         passed = False
 
     return passed
@@ -380,10 +382,7 @@ def validate_subkeys(subkeys, filename):
             passed = False
 
         # Check default values to ensure consistent type
-        if (
-            type_passed
-            and not validate_pfm_default(subkey, filename)
-        ):
+        if type_passed and not validate_pfm_default(subkey, filename):
             passed = False
 
         # Validate URLs

--- a/pre_commit_hooks/check_preference_manifests.py
+++ b/pre_commit_hooks/check_preference_manifests.py
@@ -282,7 +282,7 @@ def validate_pfm_default(subkey, filename):
                 #         continue
                 # else:
                 desired_type = PLIST_TYPES[subkey["pfm_type"]]
-                if isinstance(subkey[test_key], desired_type):
+                if not isinstance(subkey[test_key], desired_type):
                     print(
                         f"{filename}: {test_key} value for {subkey.get('pfm_name')} should be type "
                         f"{PLIST_TYPES[subkey['pfm_type']]}, not type {type(subkey[test_key])}"

--- a/pre_commit_hooks/check_preference_manifests.py
+++ b/pre_commit_hooks/check_preference_manifests.py
@@ -184,7 +184,7 @@ def validate_pfm_type_strings(subkey, filename):
         print(f'{filename}: WARNING: Subkey type "{subkey["pfm_type"]}" is deprecated')
         # passed = False
     elif subkey["pfm_type"] not in PLIST_TYPES:
-        print(f'{filename}: Unexpected subkey type "{subkey["pfm_type"]}"')
+        print(f'{filename}: Unexpected subkey type {subkey["pfm_type"]} for {subkey.get("pfm_name")}')
         passed = False
 
     return passed
@@ -333,6 +333,7 @@ def validate_platforms(subkey, filename):
 def validate_subkeys(subkeys, filename):
     """Given a list of subkeys, run validation on their contents."""
     passed = True
+    type_passed = True
 
     for subkey in subkeys:
 
@@ -355,6 +356,7 @@ def validate_subkeys(subkeys, filename):
         # Check for rogue pfm_type strings and deprecated keys.
         if not validate_pfm_type_strings(subkey, filename):
             passed = False
+            type_passed = False
 
         # TODO: Suggest adding a title if one is missing
         # if "pfm_title" not in subkey:
@@ -378,7 +380,10 @@ def validate_subkeys(subkeys, filename):
             passed = False
 
         # Check default values to ensure consistent type
-        if not validate_pfm_default(subkey, filename):
+        if (
+            type_passed
+            and not validate_pfm_default(subkey, filename)
+        ):
             passed = False
 
         # Validate URLs

--- a/pre_commit_hooks/util.py
+++ b/pre_commit_hooks/util.py
@@ -17,7 +17,6 @@ PLIST_TYPES = {
     "integer": int,
     "array": list,
     "data": None,  # TODO: How to represent this?
-    "float": float,
     "real": float,
     "date": datetime,
 }


### PR DESCRIPTION
This PR improves preference manifest checking around property types and property default value types.

As part of this, `float` was removed from `PLIST_TYPES`. However JSON checking relied on `PLIST_TYPES` so that reliance was walso removed in favor of the checker's own type map. This seems to also work better for dictionary properties with default values.

Cheers 🙂