### PR TITLE
fix: deprecationwarning only is a valid munki recipe

### DIFF
--- a/pre_commit_macadmin_hooks/check_autopkg_recipes.py
+++ b/pre_commit_macadmin_hooks/check_autopkg_recipes.py
@@ -501,6 +501,9 @@ def validate_required_proc_for_types(process, filename):
                 # their parent is a download recipe that produces a pkg.
                 # TODO: Validate parent is a download recipe.
                 break
+            if recipe_type == "munki" and "DeprecationWarning" in processors:
+                # DeprecationWarning is ok being the only processor in a munki recipe or in it at all
+                break
             if not any([x in processors for x in req_procs]):
                 if len(req_procs) == 1:
                     print(


### PR DESCRIPTION
When the DeprecationWarning processor is the only item in the recipe, check_autopkg_recipes fails. See
https://results.pre-commit.ci/run/github/26050303/1773686629.e6Qcww84S7KZAhhBT0dOlg

I think this is a better approach vs failing the pre-commit hook.